### PR TITLE
Remove version: latest from biome setup action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,8 +17,6 @@ jobs:
 
       - name: Setup Biome CLI
         uses: biomejs/setup-biome@v2
-        with:
-          version: latest
 
       - name: Run Biome
         run: biome ci .


### PR DESCRIPTION
Removes the explicit `version: latest` from the biome CI action to avoid breaking changes.