### PR TITLE
Handle expected Discord errors in automod

### DIFF
--- a/src/commands/info/blueprints.ts
+++ b/src/commands/info/blueprints.ts
@@ -1,5 +1,5 @@
 import type { ChatInputCommandInteraction } from 'discord.js';
-import { SlashCommandBuilder } from 'discord.js';
+import { MessageFlags, SlashCommandBuilder } from 'discord.js';
 
 export const data = new SlashCommandBuilder()
 	.setName('blueprints')
@@ -20,6 +20,6 @@ export async function execute(
 	await interaction.reply({
 		content:
 			"Blueprints are what you use to craft parts for your drill. There are 4 parts in total: Drill, Engine, Cargo and Cooler. Currently there are 36 levels of blueprints, with the exception of Cargo which ends at 28.\n\nBlueprint Lvl's 1-5 can be found at the Drill Center on Earth.\n\nBlueprint Lvl's 6-9 can be found after you've acquired the Golem at 50km.\n\nBlueprint Lvl's 10-13 can be found after you've acquired the Broken Robot at 225km.\n\nBlueprint Lvl's 14-17 can be found either through Golden Chests or trading through the Trader.\n\nBlueprint Lvl's 18-20 can be crafted or found through the Trader after you've reached the Moon at 1032km.\n\nBlueprint Lvl's 21-23  can be acquired through the Trader or found in Golden Chests.\n\nBlueprint Lvl's 24-26 can be found after you've reached the Robot MK2 located at 1257km (W2-225km). They can also be found through trading at the Trader.\n\nBlueprint Lvl's 27-32 can be found through Golden Chests or trading through the Trader.\n\nBlueprint Lvl's 33-36 can be found once you reach titan unlocked at Km 1814.",
-		ephemeral,
+		flags: ephemeral ? MessageFlags.Ephemeral : undefined,
 	});
 }

--- a/src/commands/info/bosses.ts
+++ b/src/commands/info/bosses.ts
@@ -1,5 +1,5 @@
 import type { ChatInputCommandInteraction } from 'discord.js';
-import { SlashCommandBuilder } from 'discord.js';
+import { MessageFlags, SlashCommandBuilder } from 'discord.js';
 
 export const data = new SlashCommandBuilder()
 	.setName('bosses')
@@ -20,6 +20,6 @@ export async function execute(
 	await interaction.reply({
 		content:
 			'Bosses are always ||100km|| apart ( with an exception of ||1000km|| ), starting at ||400km|| with the first boss.\nThe bosses on the ||moon|| are just shifted a little bit and are starting at ||1132km|| and then the next one continuing after ||100km||.\nWhen you arrive at a km with a boss, your drill will stop digging any more km, until you defeat the boss.\nIf you lose the fight, nothing will happen and the boss will just be there, until you finally beat him.\nIf you cannot defeat the boss, try getting/upgrading some weapons or get some combat relics.',
-		ephemeral,
+		flags: ephemeral ? MessageFlags.Ephemeral : undefined,
 	});
 }

--- a/src/commands/info/chests.ts
+++ b/src/commands/info/chests.ts
@@ -1,5 +1,5 @@
 import type { ChatInputCommandInteraction } from 'discord.js';
-import { SlashCommandBuilder } from 'discord.js';
+import { MessageFlags, SlashCommandBuilder } from 'discord.js';
 
 export const data = new SlashCommandBuilder()
 	.setName('chests')
@@ -20,6 +20,6 @@ export async function execute(
 	await interaction.reply({
 		content:
 			"Chests are found by miners.\nThe deeper you go the more miners you have & the more chances of a chest being found.\nChests even spawn while at full capacity.\nGold chests are the rarest and have a 1/158 drop chance.\nThey contain the best rewards but it could take a long time to get what you want from them.\nChests have timers so it's best to check every 5-10 minutes for them before they expire as you wouldn't want to miss a gold one.",
-		ephemeral,
+		flags: ephemeral ? MessageFlags.Ephemeral : undefined,
 	});
 }

--- a/src/commands/info/city.ts
+++ b/src/commands/info/city.ts
@@ -1,5 +1,5 @@
 import type { ChatInputCommandInteraction } from 'discord.js';
-import { SlashCommandBuilder } from 'discord.js';
+import { MessageFlags, SlashCommandBuilder } from 'discord.js';
 
 export const data = new SlashCommandBuilder()
 	.setName('city')
@@ -20,6 +20,6 @@ export async function execute(
 	await interaction.reply({
 		content:
 			'||The Underground City|| is located at ||303Km|| and is where you upgrade weapons, drill for oil and complete the 2nd lot of quests.',
-		ephemeral,
+		flags: ephemeral ? MessageFlags.Ephemeral : undefined,
 	});
 }

--- a/src/commands/info/codes.ts
+++ b/src/commands/info/codes.ts
@@ -1,5 +1,5 @@
 import type { ChatInputCommandInteraction } from 'discord.js';
-import { SlashCommandBuilder } from 'discord.js';
+import { MessageFlags, SlashCommandBuilder } from 'discord.js';
 
 export const data = new SlashCommandBuilder()
 	.setName('codes')
@@ -20,6 +20,6 @@ export async function execute(
 	await interaction.reply({
 		content:
 			'The devs create the codes.\nThe codes are given out randomly.\nPlease do not ask for any codes.\nNEVER ask the devs for any codes.\nLook in <#764279333262852138> for codes.\nThe codes expire after a certain amount of time.',
-		ephemeral,
+		flags: ephemeral ? MessageFlags.Ephemeral : undefined,
 	});
 }

--- a/src/commands/info/core.ts
+++ b/src/commands/info/core.ts
@@ -1,5 +1,5 @@
 import type { ChatInputCommandInteraction } from 'discord.js';
-import { SlashCommandBuilder } from 'discord.js';
+import { MessageFlags, SlashCommandBuilder } from 'discord.js';
 
 export const data = new SlashCommandBuilder()
 	.setName('core')
@@ -20,6 +20,6 @@ export async function execute(
 	await interaction.reply({
 		content:
 			'There are two types of sacrificing, material and relic sacrificing:\n\nMaterial Sacrificing:\nThrowing in any earth materials will either give you "nothing happens" or around the same value of another earth material, value can be slightly higher or lower to add some variance.\n\nRelic Sacrificing:\nThrowing in any relic will either give you "nothing happens" or sometimes it can give you another relic back. The relics returned are based on what is thrown in for example endless miner speed potions can give you back endless drill speed potions, endless scientist speed potions, endless gem speed potions and a few others.',
-		ephemeral,
+		flags: ephemeral ? MessageFlags.Ephemeral : undefined,
 	});
 }

--- a/src/commands/info/faq.ts
+++ b/src/commands/info/faq.ts
@@ -1,5 +1,5 @@
 import type { ChatInputCommandInteraction } from 'discord.js';
-import { SlashCommandBuilder } from 'discord.js';
+import { MessageFlags, SlashCommandBuilder } from 'discord.js';
 
 export const data = new SlashCommandBuilder()
 	.setName('faq')
@@ -19,6 +19,6 @@ export async function execute(
 
 	await interaction.reply({
 		content: '<https://mrmine.fandom.com/wiki/Frequently_Asked_Questions>',
-		ephemeral,
+		flags: ephemeral ? MessageFlags.Ephemeral : undefined,
 	});
 }

--- a/src/commands/info/golem.ts
+++ b/src/commands/info/golem.ts
@@ -1,5 +1,5 @@
 import type { ChatInputCommandInteraction } from 'discord.js';
-import { SlashCommandBuilder } from 'discord.js';
+import { MessageFlags, SlashCommandBuilder } from 'discord.js';
 
 export const data = new SlashCommandBuilder()
 	.setName('golem')
@@ -20,6 +20,6 @@ export async function execute(
 	await interaction.reply({
 		content:
 			'The Golem can be found at ||50Km||, he ||lives in a cave to the left|| and sells blueprints.',
-		ephemeral,
+		flags: ephemeral ? MessageFlags.Ephemeral : undefined,
 	});
 }

--- a/src/commands/info/hotkeys.ts
+++ b/src/commands/info/hotkeys.ts
@@ -1,5 +1,5 @@
 import type { ChatInputCommandInteraction } from 'discord.js';
-import { SlashCommandBuilder } from 'discord.js';
+import { MessageFlags, SlashCommandBuilder } from 'discord.js';
 
 export const data = new SlashCommandBuilder()
 	.setName('hotkeys')
@@ -20,6 +20,6 @@ export async function execute(
 	await interaction.reply({
 		content:
 			'the game tells you very few of the hotkeys available so here are the rest of them\n<https://mrmine.fandom.com/wiki/Shortcuts> this wiki page has the all the available ones listed',
-		ephemeral,
+		flags: ephemeral ? MessageFlags.Ephemeral : undefined,
 	});
 }

--- a/src/commands/info/lint.ts
+++ b/src/commands/info/lint.ts
@@ -1,5 +1,5 @@
 import type { ChatInputCommandInteraction } from 'discord.js';
-import { SlashCommandBuilder } from 'discord.js';
+import { MessageFlags, SlashCommandBuilder } from 'discord.js';
 
 export const data = new SlashCommandBuilder()
 	.setName('lint')
@@ -20,6 +20,6 @@ export async function execute(
 	await interaction.reply({
 		content:
 			'Pieces of Lint are likely nothing. Probably best to throw them down a hole...',
-		ephemeral,
+		flags: ephemeral ? MessageFlags.Ephemeral : undefined,
 	});
 }

--- a/src/commands/info/manager.ts
+++ b/src/commands/info/manager.ts
@@ -1,5 +1,5 @@
 import type { ChatInputCommandInteraction } from 'discord.js';
-import { SlashCommandBuilder } from 'discord.js';
+import { MessageFlags, SlashCommandBuilder } from 'discord.js';
 
 export const data = new SlashCommandBuilder()
 	.setName('manager')
@@ -20,6 +20,6 @@ export async function execute(
 	await interaction.reply({
 		content:
 			"Currently there are 3 levels of managers. All 3 levels of manager can be crafted in the Top Level section of the crafting tab. The effects for each level are as follows:\n\nManager Lv 1: Unlocks the Lock function where you can set ores to be sold until amount. Also allows for Offline Progression, where you'll receive 25% or your normal progress for 12 hours.\nManager Lv2: Grants a small increase of finding rarer materials (excluding the isotopes). Increases the effect Offline Progression, where you'll receive 50% of your normal progress for 24 hours.\nManager Lv3: Grants a small increase to find normal chests. Increases the effect of Offline Progression, where you'll receive 100% of your normal progress for 48 hours.\n\nNote: During Offline Progression it will only count towards your depth and the ores/isotopes that are mined. Only chests that go to Chest Collector are counted and also no fights from monsters will be included in offline progression.",
-		ephemeral,
+		flags: ephemeral ? MessageFlags.Ephemeral : undefined,
 	});
 }

--- a/src/commands/info/metaldetector.ts
+++ b/src/commands/info/metaldetector.ts
@@ -1,5 +1,5 @@
 import type { ChatInputCommandInteraction } from 'discord.js';
-import { SlashCommandBuilder } from 'discord.js';
+import { MessageFlags, SlashCommandBuilder } from 'discord.js';
 
 export const data = new SlashCommandBuilder()
 	.setName('metaldetector')
@@ -20,6 +20,6 @@ export async function execute(
 	await interaction.reply({
 		content:
 			"The Metal Detector is a structure that can be crafted in the Craft Center. Currently, there are 6 levels. The effects of each are as follows:\n\nLevel 1: An object near the left of the Sell Center will appear. It will blink a red light whenever a chest is present in the mine.\n\nLevel 2: Chests and Gold Chests are now marked on the scroll bar as brown dots. Gold Chests will also display a message at the top of the screen when they appear.\n\nLevel 3: Gold Chests are now marked on the scroll bar as yellow dots. Additional messages will also appear telling the depth of the chest and how long it will remain spawned for.\n\nLevel 4: The spacebar may now be used to jump to spawned chests, Orange Fish, mineral deposits, and monsters, in that order.\n\nLevel 5: Chests and mineral deposits that are close to expiring will now blink on the scroll bar. Orange Fish are now marked on the scroll bar with an orange line. Chests may now be opened by clicking anywhere on the level they're spawned.\n\nLevel 6: Spawned chests may now be manually placed into the Chest Collector by clicking a button in the Chest Collector window.",
-		ephemeral,
+		flags: ephemeral ? MessageFlags.Ephemeral : undefined,
 	});
 }

--- a/src/commands/info/milestones.ts
+++ b/src/commands/info/milestones.ts
@@ -1,5 +1,5 @@
 import type { ChatInputCommandInteraction } from 'discord.js';
-import { SlashCommandBuilder } from 'discord.js';
+import { MessageFlags, SlashCommandBuilder } from 'discord.js';
 
 export const data = new SlashCommandBuilder()
 	.setName('milestones')
@@ -20,6 +20,6 @@ export async function execute(
 	await interaction.reply({
 		content:
 			"Here's a list of all the features unlocked by reaching certain levels.\n\n10km - ||Super Miners - Allows Super Miners to be upgraded or scrapped, and for more slots to be purchased||\n15km - ||Trading Post - Trade money or minerals for various rewards||\n45km - ||Cave Building - Access caves, where drones can be used to find various rewards||\n50km - ||Golem - Unlock level 6-9 drill parts||\n100km - ||Chest Collector - Automatically stores chests at the top of the mine||\n225km - ||Broken Robot - Unlock level 10-13 drill parts||\n300-303km - ||Underground City - Unlocks the Oil Pump, Gem Forge, Weapons, and monsters||\n501km - ||The Core - Sacrifice minerals, relics, and scientists for a chance to get a similar reward back||\n700km - ||Chest Compressor - Convert Basic Chests into Gold Chests and Gold Chests into Ethereal Chests||\n1000-1032km - ||The Moon (W2) - Unlock level 18-20 drill parts and new resources to collect. Also has its own Hire Center to buy and upgrade workers||\n1047km ||(W2-15km) - Moon Trading Post - Trade money or minerals for various rewards||\n1133-1134km ||(W2-101-102km) - Reactor - Generate Nuclear Energy and create special isotopes||\n1135km ||(W2-103km) - Buff Lab - Exchange Nuclear Energy for various buffs||\n1257km ||(W2-225km) - Robot MK2 - Unlock level 24-26 drill parts||\n1782-1814km ||(W2-750km) - Titan (W3) - Unlock level 33-36 drill parts, as well as new resources to collect. Also has its own Hire Center to buy and upgrade workers||",
-		ephemeral,
+		flags: ephemeral ? MessageFlags.Ephemeral : undefined,
 	});
 }

--- a/src/commands/info/miners.ts
+++ b/src/commands/info/miners.ts
@@ -1,5 +1,5 @@
 import type { ChatInputCommandInteraction } from 'discord.js';
-import { SlashCommandBuilder } from 'discord.js';
+import { MessageFlags, SlashCommandBuilder } from 'discord.js';
 
 export const data = new SlashCommandBuilder()
 	.setName('miners')
@@ -20,6 +20,6 @@ export async function execute(
 	await interaction.reply({
 		content:
 			'Miners increase mining speed by 10% each.\nUpgrades increase mining speed by 10% each.\nMiners find chests for you, the deeper you go the more chances of chests.',
-		ephemeral,
+		flags: ephemeral ? MessageFlags.Ephemeral : undefined,
 	});
 }

--- a/src/commands/info/monsters.ts
+++ b/src/commands/info/monsters.ts
@@ -1,5 +1,5 @@
 import type { ChatInputCommandInteraction } from 'discord.js';
-import { SlashCommandBuilder } from 'discord.js';
+import { MessageFlags, SlashCommandBuilder } from 'discord.js';
 
 export const data = new SlashCommandBuilder()
 	.setName('monsters')
@@ -20,6 +20,6 @@ export async function execute(
 	await interaction.reply({
 		content:
 			'Monsters start attacking your miners from ||304Km||, you use weapons to fight them.\nThe background flashes red when a monster attack is happening.',
-		ephemeral,
+		flags: ephemeral ? MessageFlags.Ephemeral : undefined,
 	});
 }

--- a/src/commands/info/mrmine.ts
+++ b/src/commands/info/mrmine.ts
@@ -1,5 +1,5 @@
 import type { ChatInputCommandInteraction } from 'discord.js';
-import { SlashCommandBuilder } from 'discord.js';
+import { MessageFlags, SlashCommandBuilder } from 'discord.js';
 
 export const data = new SlashCommandBuilder()
 	.setName('mrmine')
@@ -19,6 +19,6 @@ export async function execute(
 
 	await interaction.reply({
 		content: 'Mr.Mime, he does nothing',
-		ephemeral,
+		flags: ephemeral ? MessageFlags.Ephemeral : undefined,
 	});
 }

--- a/src/commands/info/oil.ts
+++ b/src/commands/info/oil.ts
@@ -1,5 +1,5 @@
 import type { ChatInputCommandInteraction } from 'discord.js';
-import { SlashCommandBuilder } from 'discord.js';
+import { MessageFlags, SlashCommandBuilder } from 'discord.js';
 
 export const data = new SlashCommandBuilder()
 	.setName('oil')
@@ -20,6 +20,6 @@ export async function execute(
 	await interaction.reply({
 		content:
 			"the reason you can get 0 oil from chests is this\nwhen you get an oil chest the game does a calc which is time-per-oil/2 hours\nwhen it does this calc with a level 0 oil rig (has 2 hours per) it gets 0.5 oil\nthen the game parses the number as an interger which cuts off everything after the decimal point\nafter it does that parce what your left with is 0 oil which is what's left of it",
-		ephemeral,
+		flags: ephemeral ? MessageFlags.Ephemeral : undefined,
 	});
 }

--- a/src/commands/info/oilrig.ts
+++ b/src/commands/info/oilrig.ts
@@ -1,5 +1,5 @@
 import type { ChatInputCommandInteraction } from 'discord.js';
-import { SlashCommandBuilder } from 'discord.js';
+import { MessageFlags, SlashCommandBuilder } from 'discord.js';
 
 export const data = new SlashCommandBuilder()
 	.setName('oilrig')
@@ -20,6 +20,6 @@ export async function execute(
 	await interaction.reply({
 		content:
 			'The oil rig is located at 303km in the Underground City.\nThe oil rig is used for:\n\nBlueprints\nGems for Upgrading Weapons\nCrafting for Reactor on the Moon\n\nOil Rig levels, capacity and costs:\n\nLvl 0 to Lvl 1: Cap 2, upgrade costs 5 Building Materials and $100 Billion\nLvl 1 to Lvl 2: Cap 4, upgrade costs 7 Building Materials and $250 Billion\nLvl 2 to Lvl 3: Cap 16, upgrade costs 10 Building Materials and $500 Billion\nLvl 3 to Lvl 4: Cap 32, upgrade costs 15 Building Materials and $1 Trillion\nLvl 4 to Lvl 5: Cap 100, upgrade costs 20 Building Materials and $2 Trillion\nLvl 5 to Lvl 6: Cap 200, upgrade costs 30 Building Materials and $3 Trillion\nLvl 6 to Lvl 7: Cap 400, upgrade costs 40 Building Materials and $5 Trillion\nLvl 7 to Lvl 8: Cap 1000, upgrade costs 50 Building Materials and $8 Trillion\nLvl 8 to Lvl 9: Cap 2000, upgrade costs 75 Building Materials and $40 Trillion\nLvl 9 to Lvl 10: Cap 4000, upgrade costs 90 Building Materials and $80 Trillion\nLvl 10 to Lvl 11: Cap 8000, upgrade costs 100 Building Materials and $400 Trillion\nLvl 11 to Lvl 12: Cap 12000, upgrade costs 150 Building Materials and $2 Quadrillion\nLvl 12 to Lvl 13: Cap 16000, upgrade costs 250 Building Materials and $50 Quadrillion\nLvl 13 to Lvl 14: Cap 20000, upgrade costs 500 Building Materials and $500 Quadrillion\nLvl 14 to Lvl 15: Cap 25000, upgrade costs 1500 Building Materials and $20 Quintillion\nLvl 15 to Lvl 16: Cap 30000, upgrade costs 5000 Building Materials and $600 Quintillion',
-		ephemeral,
+		flags: ephemeral ? MessageFlags.Ephemeral : undefined,
 	});
 }

--- a/src/commands/info/relics.ts
+++ b/src/commands/info/relics.ts
@@ -1,5 +1,5 @@
 import type { ChatInputCommandInteraction } from 'discord.js';
-import { SlashCommandBuilder } from 'discord.js';
+import { MessageFlags, SlashCommandBuilder } from 'discord.js';
 
 export const data = new SlashCommandBuilder()
 	.setName('relics')
@@ -20,6 +20,6 @@ export async function execute(
 	await interaction.reply({
 		content:
 			'Relics are gained through scientist missions.\nRelics are always activated.\nRelics effects stack except for the ones that grant consumables, resources, timelapses and relic bags.\nAll missions have a DC (Death Chance) percentage, the higher the more chance of losing your scientist.',
-		ephemeral,
+		flags: ephemeral ? MessageFlags.Ephemeral : undefined,
 	});
 }

--- a/src/commands/info/scientists.ts
+++ b/src/commands/info/scientists.ts
@@ -1,5 +1,5 @@
 import type { ChatInputCommandInteraction } from 'discord.js';
-import { SlashCommandBuilder } from 'discord.js';
+import { MessageFlags, SlashCommandBuilder } from 'discord.js';
 
 export const data = new SlashCommandBuilder()
 	.setName('scientists')
@@ -20,6 +20,6 @@ export async function execute(
 	await interaction.reply({
 		content:
 			"Scientists are sent to go on excavations with varying difficulties. Each excavation has a death chance. There are factors that can change this. The rarity of scientists can effect the death chance as well how often a rare item shows up. Level can also play a factor of how often a rare item shows up. There are currently 4 rarities of scientists. Here's how each of the rarities effects the death chance for a excavation:\n\nCommon: No Death Chance reduction.\nUncommon: Lowers Death Chance by 10%.\nRare: Lowers Death Chance by 25%.\nLegendary: Lowers Death Chance by 50%.",
-		ephemeral,
+		flags: ephemeral ? MessageFlags.Ephemeral : undefined,
 	});
 }

--- a/src/commands/info/secrets.ts
+++ b/src/commands/info/secrets.ts
@@ -1,5 +1,5 @@
 import type { ChatInputCommandInteraction } from 'discord.js';
-import { SlashCommandBuilder } from 'discord.js';
+import { MessageFlags, SlashCommandBuilder } from 'discord.js';
 
 export const data = new SlashCommandBuilder()
 	.setName('secrets')
@@ -20,6 +20,6 @@ export async function execute(
 	await interaction.reply({
 		content:
 			"Books of Secrets are used to upgrade relics and scientists at the Core (501km).\n||One Book of Secrets will turn the Core blue (corrupted). If another Book of Secrets is sacrificed while the Core is blue, you'll get a Book of Secrets+ that can be used to turn the core white (blessed).\nThe blue Core changes a relic or scientist's rarity to Warped.\nThe white Core changes a relic's rarity to Divine and scientists to Warped. **There is no divine rarity for scientists.**\nSuccess chance for relics is 100%. Success chance for scientists is 50%.\nIf an attempt fails, the relic or scientist is lost.\nThe Core only returns to normal after a successful sacrifice.||",
-		ephemeral,
+		flags: ephemeral ? MessageFlags.Ephemeral : undefined,
 	});
 }

--- a/src/commands/info/ufo.ts
+++ b/src/commands/info/ufo.ts
@@ -1,5 +1,5 @@
 import type { ChatInputCommandInteraction } from 'discord.js';
-import { SlashCommandBuilder } from 'discord.js';
+import { MessageFlags, SlashCommandBuilder } from 'discord.js';
 
 export const data = new SlashCommandBuilder()
 	.setName('ufo')
@@ -20,6 +20,6 @@ export async function execute(
 	await interaction.reply({
 		content:
 			'The UFO is a clickable that comes to visit every 10 hours, real-time. It appears on the space between the Earth and the Moon and stays only for 15 minutes. Successfully clicking it grants you an achievement.\nMore details can be found here  <https://mrmine.fandom.com/wiki/UFO>',
-		ephemeral,
+		flags: ephemeral ? MessageFlags.Ephemeral : undefined,
 	});
 }

--- a/src/commands/info/weapons.ts
+++ b/src/commands/info/weapons.ts
@@ -1,5 +1,5 @@
 import type { ChatInputCommandInteraction } from 'discord.js';
-import { SlashCommandBuilder } from 'discord.js';
+import { MessageFlags, SlashCommandBuilder } from 'discord.js';
 
 export const data = new SlashCommandBuilder()
 	.setName('weapons')
@@ -20,6 +20,6 @@ export async function execute(
 	await interaction.reply({
 		content:
 			'Weapons can be obtained after you reach the Underground City at 304km. There are 12 weapons in total. You first start out with a fist. The rest of the weapons can be acquired in the following ways:\n\nA lot of the weapons like Rock, Sword or Big Bomb could be dropped from normal chests.\nPickaxes, Mallet, Bow and Arrow could also be acquired by killing monsters.\nHeal and Time Travel could be aquired by opening Golden Chests.\nHowever all weapons can also be recieved from the scientist mission - Unlock New Weapon.\n\nThe Heal and Time Travel weapons have special effects. The heal weapon heals you for a small amount HP and Time Travel allows all your cooldowns for your weapons to jump forward by a little bit.\n\nEach weapon does its own amount of damage and has its own cooldown timer at which it fills up. Both of which can be improved by upgrading your weapons. These will require various amounts of different gems and oil. To upgrade your weapon and to see their statistics, click the right most building ( the statue of a knight ) in the Underground City',
-		ephemeral,
+		flags: ephemeral ? MessageFlags.Ephemeral : undefined,
 	});
 }

--- a/src/commands/info/wiki.ts
+++ b/src/commands/info/wiki.ts
@@ -1,5 +1,5 @@
 import type { ChatInputCommandInteraction } from 'discord.js';
-import { SlashCommandBuilder } from 'discord.js';
+import { MessageFlags, SlashCommandBuilder } from 'discord.js';
 
 export const data = new SlashCommandBuilder()
 	.setName('wiki')
@@ -20,6 +20,6 @@ export async function execute(
 	await interaction.reply({
 		content:
 			'Go to https://mrmine.fandom.com/wiki/Mr._Mine_Wiki. It is updated frequently, check it out if you need more detailed information about the game. ',
-		ephemeral,
+		flags: ephemeral ? MessageFlags.Ephemeral : undefined,
 	});
 }

--- a/src/commands/moderation/areyouhappy.ts
+++ b/src/commands/moderation/areyouhappy.ts
@@ -1,5 +1,9 @@
 import type { ChatInputCommandInteraction } from 'discord.js';
-import { PermissionFlagsBits, SlashCommandBuilder } from 'discord.js';
+import {
+	MessageFlags,
+	PermissionFlagsBits,
+	SlashCommandBuilder,
+} from 'discord.js';
 
 export const data = new SlashCommandBuilder()
 	.setName('areyouhappy')
@@ -15,7 +19,10 @@ export async function execute(
 	const user = interaction.options.getUser('user', true);
 	const channel = interaction.channel;
 
-	await interaction.reply({ content: 'sending pings', ephemeral: true });
+	await interaction.reply({
+		content: 'sending pings',
+		flags: MessageFlags.Ephemeral,
+	});
 
 	if (!channel) return;
 

--- a/src/commands/moderation/ban.ts
+++ b/src/commands/moderation/ban.ts
@@ -1,6 +1,7 @@
 import type { ChatInputCommandInteraction, TextChannel } from 'discord.js';
 import {
 	ChannelType,
+	MessageFlags,
 	PermissionFlagsBits,
 	SlashCommandBuilder,
 } from 'discord.js';
@@ -25,7 +26,10 @@ export async function execute(
 	const user = interaction.options.getUser('user', true);
 	const reason = interaction.options.getString('reason', true);
 
-	await interaction.reply({ content: 'banning user', ephemeral: true });
+	await interaction.reply({
+		content: 'banning user',
+		flags: MessageFlags.Ephemeral,
+	});
 
 	// guild.bans.create accepts a User directly as a resolvable
 	await interaction.guild.bans.create(user, {

--- a/src/commands/moderation/kick.ts
+++ b/src/commands/moderation/kick.ts
@@ -1,6 +1,7 @@
 import type { ChatInputCommandInteraction, TextChannel } from 'discord.js';
 import {
 	ChannelType,
+	MessageFlags,
 	PermissionFlagsBits,
 	SlashCommandBuilder,
 } from 'discord.js';
@@ -25,7 +26,10 @@ export async function execute(
 	const user = interaction.options.getUser('user', true);
 	const reason = interaction.options.getString('reason', true);
 
-	await interaction.reply({ content: 'Kicking user', ephemeral: true });
+	await interaction.reply({
+		content: 'Kicking user',
+		flags: MessageFlags.Ephemeral,
+	});
 
 	// guild.members.kick accepts a User directly as a resolvable
 	await interaction.guild.members.kick(user, reason);

--- a/src/commands/utility/getreactions.ts
+++ b/src/commands/utility/getreactions.ts
@@ -7,6 +7,7 @@ import type {
 import {
 	AttachmentBuilder,
 	Collection,
+	MessageFlags,
 	PermissionFlagsBits,
 	SlashCommandBuilder,
 } from 'discord.js';
@@ -60,7 +61,7 @@ export async function execute(
 
 	await interaction.reply({
 		content: 'Fetching reactions... This might take a few seconds.',
-		ephemeral: true,
+		flags: MessageFlags.Ephemeral,
 	});
 
 	try {

--- a/src/events/interactionCreate.ts
+++ b/src/events/interactionCreate.ts
@@ -1,6 +1,6 @@
 import * as Sentry from '@sentry/node';
 import type { Client } from 'discord.js';
-import { Events } from 'discord.js';
+import { Events, MessageFlags } from 'discord.js';
 
 export function registerInteractionCreate(client: Client): void {
 	client.on(Events.InteractionCreate, async (interaction) => {
@@ -26,15 +26,16 @@ export function registerInteractionCreate(client: Client): void {
 				user: { id: interaction.user.id, username: interaction.user.username },
 			});
 
-			const errorMessage = {
-				content: 'There was an error while executing this command!',
-				ephemeral: true,
-			};
-
 			if (interaction.replied || interaction.deferred) {
-				await interaction.followUp(errorMessage);
+				await interaction.followUp({
+					content: 'There was an error while executing this command!',
+					flags: MessageFlags.Ephemeral,
+				});
 			} else {
-				await interaction.reply(errorMessage);
+				await interaction.reply({
+					content: 'There was an error while executing this command!',
+					flags: MessageFlags.Ephemeral,
+				});
 			}
 		}
 	});

--- a/src/services/automod.ts
+++ b/src/services/automod.ts
@@ -1,11 +1,33 @@
 import {
 	ChannelType,
+	DiscordAPIError,
 	type Message,
 	PermissionsBitField,
 	type TextChannel,
 } from 'discord.js';
+import * as Sentry from '@sentry/node';
 import { config } from '../config.ts';
 import { log } from '../utils/logger.ts';
+
+/** Discord API error codes that are expected and safe to ignore in automod. */
+const IGNORED_DISCORD_ERRORS = new Set([
+	10008, // Unknown Message - already deleted
+	50278, // Cannot send messages to this user - DMs disabled
+]);
+
+/**
+ * Silently ignores expected Discord API errors (e.g. message already deleted, DMs disabled)
+ * and reports anything unexpected to Sentry.
+ */
+function handleDiscordError(error: unknown): void {
+	if (
+		error instanceof DiscordAPIError &&
+		IGNORED_DISCORD_ERRORS.has(Number(error.code))
+	) {
+		return;
+	}
+	Sentry.captureException(error);
+}
 
 // Module-level state for spam tracking - intentionally process-scoped
 const userMessageHistory: Record<string, number[]> = {};
@@ -62,7 +84,7 @@ async function checkNitroScam(message: Message<true>): Promise<void> {
 	if (!isNitroScam) return;
 
 	console.log(message.content);
-	await message.delete();
+	await message.delete().catch(handleDiscordError);
 	message.member
 		?.ban({
 			deleteMessageSeconds: 7 * 24 * 60 * 60,
@@ -81,11 +103,11 @@ async function checkDiscordLinks(
 	if (!isNewMember) return;
 	if (!message.content.toLowerCase().includes('discord.gg')) return;
 
-	await message.delete();
+	await message.delete().catch(handleDiscordError);
 	log(`Link posted by ${message.author.username}`);
 	message.member
 		?.send('Do not post links to other Discord Servers')
-		.catch(console.error);
+		.catch(handleDiscordError);
 	getAuditChannel(message)?.send({
 		content: `Warned <@${message.member?.id}> for posting links to a different Discord server.`,
 	});
@@ -97,12 +119,12 @@ async function checkRacistWords(message: Message<true>): Promise<void> {
 	for (const word of AUTO_BAN_WORDS) {
 		if (!lc.includes(word)) continue;
 
-		await message.delete();
+		await message.delete().catch(handleDiscordError);
 		message.member
 			?.send(
 				'You have been banned from the Mr. Mine Discord for posting racist comments.',
 			)
-			.catch(console.error);
+			.catch(handleDiscordError);
 		message.member
 			?.ban({
 				deleteMessageSeconds: 7 * 24 * 60 * 60,
@@ -143,10 +165,10 @@ async function checkMessageSpam(
 
 	if (hasModPerms(message)) return;
 
-	await message.delete();
+	await message.delete().catch(handleDiscordError);
 	message.member
 		?.send('You have been banned for spamming')
-		.catch(console.error);
+		.catch(handleDiscordError);
 	message.member
 		?.ban({ deleteMessageSeconds: 7 * 24 * 60 * 60, reason: 'spamming' })
 		.catch(console.error);
@@ -192,10 +214,10 @@ async function checkChannelSpam(
 
 	if (hasModPerms(message)) return;
 
-	await message.delete();
+	await message.delete().catch(handleDiscordError);
 	message.member
 		?.send('You have been banned for spamming')
-		.catch(console.error);
+		.catch(handleDiscordError);
 	message.member
 		?.ban({ deleteMessageSeconds: 7 * 24 * 60 * 60, reason: 'spamming' })
 		.catch(console.error);

--- a/src/services/automod.ts
+++ b/src/services/automod.ts
@@ -1,3 +1,4 @@
+import * as Sentry from '@sentry/node';
 import {
 	ChannelType,
 	DiscordAPIError,
@@ -5,7 +6,6 @@ import {
 	PermissionsBitField,
 	type TextChannel,
 } from 'discord.js';
-import * as Sentry from '@sentry/node';
 import { config } from '../config.ts';
 import { log } from '../utils/logger.ts';
 


### PR DESCRIPTION
Fixes MINE-BOT-9 and MINE-BOT-A.

The automod was throwing unhandled errors when trying to delete an already-deleted message (10008) or DM a user with DMs disabled (50278). These are expected edge cases in moderation - the action still succeeds (user gets banned), just the cleanup fails.

Added a `handleDiscordError` helper that silently ignores these two error codes and reports anything else to Sentry.