### PR TITLE
Fix deprecated ephemeral option and DM error handling

### DIFF
--- a/src/commands/utility/role.ts
+++ b/src/commands/utility/role.ts
@@ -1,5 +1,5 @@
 import type { ChatInputCommandInteraction } from 'discord.js';
-import { SlashCommandBuilder } from 'discord.js';
+import { MessageFlags, SlashCommandBuilder } from 'discord.js';
 
 export const data = new SlashCommandBuilder()
 	.setName('role')
@@ -20,6 +20,6 @@ export async function execute(
 	await interaction.reply({
 		content:
 			"Just go into the in game settings click export and DM <@!764713414206423061> with that code and you should automatically get a role. It's okay if the message is over 2000 characters and gets turned in to a txt file, it can still read it. For further explanations go and read <#808451078201802812>. The roles don't update by themselves, so you will have to do it again, every time you reach the next role requirements.",
-		ephemeral,
+		flags: ephemeral ? MessageFlags.Ephemeral : undefined,
 	});
 }

--- a/src/services/automod.ts
+++ b/src/services/automod.ts
@@ -6,13 +6,15 @@ import {
 	PermissionsBitField,
 	type TextChannel,
 } from 'discord.js';
+import { RESTJSONErrorCodes } from 'discord-api-types/v10';
 import { config } from '../config.ts';
 import { log } from '../utils/logger.ts';
 
-/** Discord API error codes that are expected and safe to ignore in automod. */
+/** Discord API error codes that are expected and safe to ignore. */
 const IGNORED_DISCORD_ERRORS = new Set([
-	10008, // Unknown Message - already deleted
-	50278, // Cannot send messages to this user - DMs disabled
+	RESTJSONErrorCodes.UnknownMessage,
+	RESTJSONErrorCodes.UnknownInteraction,
+	RESTJSONErrorCodes.CannotSendMessagesToThisUser,
 ]);
 
 const AUTO_BAN_WORDS = ['nigger', 'nigga', 'jew', 'n1gger', 'n!gger'];
@@ -21,7 +23,7 @@ const AUTO_BAN_WORDS = ['nigger', 'nigga', 'jew', 'n1gger', 'n!gger'];
  * Silently ignores expected Discord API errors (e.g. message already deleted, DMs disabled)
  * and reports anything unexpected to Sentry.
  */
-function handleDiscordError(error: unknown): void {
+export function handleDiscordError(error: unknown): void {
 	if (
 		error instanceof DiscordAPIError &&
 		IGNORED_DISCORD_ERRORS.has(Number(error.code))

--- a/src/services/channelMod.ts
+++ b/src/services/channelMod.ts
@@ -1,5 +1,6 @@
 import { type Message, PermissionsBitField } from 'discord.js';
 import { config } from '../config.ts';
+import { handleDiscordError } from './automod.ts';
 
 const BUG_REPORTS_CHANNEL = '761441663397789696';
 const MOBILE_BUG_REPORTS_CHANNEL = '1427421373248180324';
@@ -60,8 +61,7 @@ export class ChannelModService {
 					'Hey, it appears you posted in the bug reports channel with out the proper format. If your message was a bug report, please edit it to include "report:" , preferably including the game version and patch letter, and resend it to the bug reports channel, thanks! \n\n Message Copy: ' +
 					message.content,
 			})
-			.then(console.log)
-			.catch(console.error);
+			.catch(handleDiscordError);
 
 		message.channel
 			.send({
@@ -94,8 +94,7 @@ export class ChannelModService {
 					'Hey, it appears you posted in the mobile bug reports channel without the proper format. If your message was a bug report, please edit it to include "Report Android:" or "Report IOS:" and resend it to the mobile bug reports channel, thanks! \n\n Message Copy: ' +
 					message.content,
 			})
-			.then(console.log)
-			.catch(console.error);
+			.catch(handleDiscordError);
 
 		message.channel
 			.send({
@@ -130,8 +129,7 @@ export class ChannelModService {
 					'Hey, it appears you posted in the ideas and suggestions channel with out the proper format. If your message was an idea, please edit it to include "idea:" and resend it to the ideas channel, thanks! \n\n Message Copy:' +
 					message.content,
 			})
-			.then(console.log)
-			.catch(console.error);
+			.catch(handleDiscordError);
 
 		message.channel
 			.send({


### PR DESCRIPTION
Replace deprecated `ephemeral` property with `MessageFlags.Ephemeral` in the role command, and use `handleDiscordError` for DM sends in channel moderation so expected errors like "Cannot send messages to this user" don't create Sentry noise.

Also replaces hardcoded Discord error codes with named `RESTJSONErrorCodes` constants.

Fixes MINE-BOT-8, MINE-BOT-A