### PR TITLE
Audit bot feature usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,10 @@ Each chat-driven feature can be switched off without a code change. Set the flag
 
 The Message Content privileged intent is requested only while at least one text-reading feature is on. Turn all eight off and the bot connects without it. The startup log reports which features are disabled and whether the intent was requested.
 
+### Activity Audit
+
+User-visible bot actions are appended to daily `logs/audit-YYYY-MM-DD.jsonl` files. Each line contains a timestamp, a stable event name, and relevant IDs or outcome metadata.
+
 ### 4. Start the Bot
 
 ```bash
@@ -106,4 +110,3 @@ pm2 save
 ## 📜 License
 
 This project is licensed under the MIT License (as specified in `package.json`).
-

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -23,6 +23,7 @@ import { ChannelModService } from './services/channelMod.ts';
 import { RoleService } from './services/roles.ts';
 import { SaveService } from './services/saves.ts';
 import type { Command } from './types/index.ts';
+import { audit } from './utils/audit.ts';
 import { log } from './utils/logger.ts';
 
 const COMMANDS_DIR = join(dirname(fileURLToPath(import.meta.url)), 'commands');
@@ -74,6 +75,12 @@ export class Bot {
 	 */
 	async start(): Promise<void> {
 		this.logFeatures();
+		audit('bot.started', {
+			enabledFeatures: Object.entries(config.features)
+				.filter(([, enabled]) => enabled)
+				.map(([name]) => name),
+			messageContentRequested: config.requiresMessageContent,
+		});
 
 		this._client.commands = new Collection<string, Command>();
 
@@ -238,7 +245,19 @@ export class Bot {
 
 		try {
 			await command.execute(interaction);
+			audit('command.executed', {
+				channelId: interaction.channelId,
+				command: interaction.commandName,
+				guildId: interaction.guildId,
+				userId: interaction.user.id,
+			});
 		} catch (error) {
+			audit('command.failed', {
+				channelId: interaction.channelId,
+				command: interaction.commandName,
+				guildId: interaction.guildId,
+				userId: interaction.user.id,
+			});
 			console.error(error);
 
 			Sentry.captureException(error, {
@@ -285,6 +304,12 @@ export class Bot {
 				hasQuestionStarter &&
 				(lc.includes('red star') || lc.includes('red name'))
 			) {
+				audit('auto_response.red_names', {
+					channelId: message.channel.id,
+					guildId: message.guildId,
+					temporaryMessageContent: message.content,
+					userId: message.author.id,
+				});
 				await message.reply({
 					content:
 						'The red names are the names of players who chose to support the game by buying 650 tickets or 1400 tickets at one time.',
@@ -293,6 +318,12 @@ export class Bot {
 				hasQuestionStarter &&
 				(lc.includes('mime') || lc.includes('112'))
 			) {
+				audit('auto_response.mr_mime', {
+					channelId: message.channel.id,
+					guildId: message.guildId,
+					temporaryMessageContent: message.content,
+					userId: message.author.id,
+				});
 				await message.reply({
 					content: "That's Mr. Mime, he's just vibin. He doesn't do anything.",
 				});
@@ -302,6 +333,12 @@ export class Bot {
 					lc.includes('are there')) &&
 				lc.includes('code')
 			) {
+				audit('auto_response.codes', {
+					channelId: message.channel.id,
+					guildId: message.guildId,
+					temporaryMessageContent: message.content,
+					userId: message.author.id,
+				});
 				await message.reply({
 					content:
 						"The devs randomly create the codes and they typically expire after a few days or uses.\nIf the latest ones in <#764279333262852138> don't work it's unlikely there is any available.\nPlease do not ask for any codes and NEVER ask the devs for codes.",

--- a/src/services/automod.ts
+++ b/src/services/automod.ts
@@ -8,6 +8,7 @@ import {
 } from 'discord.js';
 import { RESTJSONErrorCodes } from 'discord-api-types/v10';
 import { config } from '../config.ts';
+import { audit } from '../utils/audit.ts';
 import { log } from '../utils/logger.ts';
 
 /** Discord API error codes that are expected and safe to ignore. */
@@ -109,6 +110,13 @@ export class ModerationService {
 
 		if (!isNitroScam) return;
 
+		audit('moderation.nitro_scam', {
+			action: 'ban',
+			channelId: message.channel.id,
+			guildId: message.guildId,
+			temporaryMessageContent: message.content,
+			userId: message.author.id,
+		});
 		console.log(message.content);
 		await message.delete().catch(handleDiscordError);
 		message.member
@@ -133,6 +141,13 @@ export class ModerationService {
 		if (!isNewMember) return;
 		if (!message.content.toLowerCase().includes('discord.gg')) return;
 
+		audit('moderation.invite_link', {
+			action: 'delete_and_warn',
+			channelId: message.channel.id,
+			guildId: message.guildId,
+			temporaryMessageContent: message.content,
+			userId: message.author.id,
+		});
 		await message.delete().catch(handleDiscordError);
 		log(`Link posted by ${message.author.username}`);
 		message.member
@@ -154,6 +169,13 @@ export class ModerationService {
 		for (const word of AUTO_BAN_WORDS) {
 			if (!lc.includes(word)) continue;
 
+			audit('moderation.slur', {
+				action: 'ban',
+				channelId: message.channel.id,
+				guildId: message.guildId,
+				temporaryMessageContent: message.content,
+				userId: message.author.id,
+			});
 			await message.delete().catch(handleDiscordError);
 			message.member
 				?.send(
@@ -206,6 +228,15 @@ export class ModerationService {
 
 		if (ModerationService.hasModPerms(message)) return;
 
+		audit('moderation.rapid_message_spam', {
+			action: 'ban',
+			channelId: message.channel.id,
+			guildId: message.guildId,
+			messageCount: 6,
+			temporaryMessageContent: message.content,
+			userId: message.author.id,
+			windowMs: 8_000,
+		});
 		await message.delete().catch(handleDiscordError);
 		message.member
 			?.send('You have been banned for spamming')
@@ -260,6 +291,14 @@ export class ModerationService {
 
 		if (ModerationService.hasModPerms(message)) return;
 
+		audit('moderation.cross_channel_spam', {
+			action: 'ban',
+			channelIds: keys,
+			guildId: message.guildId,
+			temporaryMessageContent: message.content,
+			userId: message.author.id,
+			windowMs: 10_000,
+		});
 		await message.delete().catch(handleDiscordError);
 		message.member
 			?.send('You have been banned for spamming')

--- a/src/services/channelMod.ts
+++ b/src/services/channelMod.ts
@@ -1,5 +1,6 @@
 import { type Message, PermissionsBitField } from 'discord.js';
 import { config } from '../config.ts';
+import { audit } from '../utils/audit.ts';
 import { handleDiscordError } from './automod.ts';
 
 const BUG_REPORTS_CHANNEL = '761441663397789696';
@@ -44,6 +45,13 @@ export class ChannelModService {
 			)
 		) {
 			await message.delete();
+			audit('moderation.google_play_spam', {
+				action: 'delete',
+				channelId: message.channel.id,
+				guildId: message.guildId,
+				temporaryMessageContent: message.content,
+				userId: message.author.id,
+			});
 		}
 	}
 
@@ -57,6 +65,12 @@ export class ChannelModService {
 		if (hasModPerms(message)) return;
 
 		await message.delete();
+		audit('channel.bug_report_rejected', {
+			channelId: message.channel.id,
+			guildId: message.guildId,
+			temporaryMessageContent: message.content,
+			userId: message.author.id,
+		});
 
 		message.member
 			?.send({
@@ -91,6 +105,12 @@ export class ChannelModService {
 		if (hasModPerms(message)) return;
 
 		await message.delete();
+		audit('channel.mobile_bug_report_rejected', {
+			channelId: message.channel.id,
+			guildId: message.guildId,
+			temporaryMessageContent: message.content,
+			userId: message.author.id,
+		});
 
 		message.member
 			?.send({
@@ -121,12 +141,24 @@ export class ChannelModService {
 		if (lc.startsWith('idea:') || lc.startsWith('suggestion:')) {
 			await message.react('\u{1F44D}');
 			await message.react('\u{1F44E}');
+			audit('channel.idea_accepted', {
+				channelId: message.channel.id,
+				guildId: message.guildId,
+				temporaryMessageContent: message.content,
+				userId: message.author.id,
+			});
 			return;
 		}
 
 		if (hasModPerms(message)) return;
 
 		await message.delete();
+		audit('channel.idea_rejected', {
+			channelId: message.channel.id,
+			guildId: message.guildId,
+			temporaryMessageContent: message.content,
+			userId: message.author.id,
+		});
 
 		message.member
 			?.send({

--- a/src/services/roles.ts
+++ b/src/services/roles.ts
@@ -1,4 +1,5 @@
 import type { Client, Message } from 'discord.js';
+import { audit } from '../utils/audit.ts';
 import { log } from '../utils/logger.ts';
 import type { SaveService } from './saves.ts';
 
@@ -55,6 +56,12 @@ export class RoleService {
 
 			if (roleId) {
 				await member.roles.add(roleId);
+				audit('role.assigned', {
+					depth,
+					guildId: this._guildId,
+					roleId,
+					userId: message.author.id,
+				});
 				await message.reply(
 					'You have been assigned a role on the Mr. Mine Discord. Post a message in chat to see it.',
 				);

--- a/src/services/saves.ts
+++ b/src/services/saves.ts
@@ -2,6 +2,7 @@ import type { Message } from 'discord.js';
 import { config } from '../config.ts';
 import { persistBannedFromRoles, store } from '../data.ts';
 import type { DataStore } from '../types/index.ts';
+import { audit } from '../utils/audit.ts';
 import { log } from '../utils/logger.ts';
 import type { RoleService } from './roles.ts';
 
@@ -46,6 +47,10 @@ export class SaveService {
 	 */
 	async processDmMessage(message: Message): Promise<void> {
 		if (store.bannedFromRoles.includes(message.author.id)) {
+			audit('save.rejected', {
+				reason: 'user_already_banned',
+				userId: message.author.id,
+			});
 			await message.reply(
 				'Your save was determined to be illegitimate either because you cheated or used a different users save. You will no longer be eligible for ranks on the server.',
 			);
@@ -56,11 +61,19 @@ export class SaveService {
 
 		const attachment = message.attachments.first();
 		if (attachment?.name === 'message.txt') {
+			audit('save.received', {
+				input: 'attachment',
+				userId: message.author.id,
+			});
 			try {
 				const response = await fetch(attachment.url);
 				const data = await response.text();
 				await this.processSaveData(data, message);
 			} catch (error) {
+				audit('save.failed', {
+					reason: 'attachment_download_failed',
+					userId: message.author.id,
+				});
 				console.error('Error downloading save attachment:', error);
 			}
 			return;
@@ -71,6 +84,10 @@ export class SaveService {
 			message.content.includes('|') &&
 			!message.content.includes(' ')
 		) {
+			audit('save.received', {
+				input: 'message',
+				userId: message.author.id,
+			});
 			await this.processSaveData(message.content, message);
 			return;
 		}
@@ -84,6 +101,10 @@ export class SaveService {
 	 */
 	private async processSaveData(data: string, message: Message): Promise<void> {
 		if (!data.includes('|')) {
+			audit('save.rejected', {
+				reason: 'unsupported_format',
+				userId: message.author.id,
+			});
 			await message.reply(
 				"Your save is missing data, please make sure to paste all of the text. It's okay if Discord asks you to convert it to a file.\nIf you sent me your save by clicking on my name on the right pannel and pasting the text in the little box, Discord automatically cuts the text to 500 characters. So please send it from the actual DM page.",
 			);
@@ -93,6 +114,10 @@ export class SaveService {
 		const save = SaveService.decodeSave(data);
 
 		if (save.length < 450) {
+			audit('save.rejected', {
+				reason: 'incomplete_save',
+				userId: message.author.id,
+			});
 			await message.reply(
 				"Your save is missing data, please make sure to paste all of the text. It's okay if Discord asks you to convert it to a file.\nIf you sent me your save by clicking on my name on the right pannel and pasting the text in the little box, Discord automatically cuts the text to 500 characters. So please send it from this DM actual DM page.",
 			);
@@ -143,6 +168,10 @@ export class SaveService {
 		}
 
 		if (!userBanned && !store.bannedFromRoles.includes(message.author.id)) {
+			audit('save.accepted', {
+				depth: Number(depth),
+				userId: message.author.id,
+			});
 			store.saves.push({
 				userID: message.author.id,
 				depth,
@@ -152,6 +181,10 @@ export class SaveService {
 			});
 			await this._roleService.setRole(Number(depth), message);
 		} else if (!store.bannedFromRoles.includes(message.author.id)) {
+			audit('save.banned', {
+				reason: 'validation_failed',
+				userId: message.author.id,
+			});
 			store.bannedFromRoles.push(message.author.id);
 			persistBannedFromRoles();
 

--- a/src/utils/audit.ts
+++ b/src/utils/audit.ts
@@ -1,0 +1,30 @@
+import { appendFileSync, mkdirSync } from 'node:fs';
+import path from 'node:path';
+
+/** Scalar values allowed in audit event context. */
+export type AuditValue = string | number | boolean | null;
+
+/** Identifying and outcome metadata attached to an audit event. */
+export type AuditContext = Record<string, AuditValue | AuditValue[]>;
+
+/** Directory containing the daily audit files. */
+const AUDIT_DIRECTORY = path.join(process.cwd(), 'logs');
+
+/**
+ * Appends one structured event to the daily audit file.
+ *
+ * @param event - Stable event name used for counting and filtering.
+ * @param context - Relevant IDs, outcomes, and temporary content when provided.
+ */
+export function audit(event: string, context: AuditContext = {}): void {
+	try {
+		const timestamp = new Date().toISOString();
+		const fileName = `audit-${timestamp.slice(0, 10)}.jsonl`;
+		const entry = JSON.stringify({ timestamp, event, context });
+
+		mkdirSync(AUDIT_DIRECTORY, { recursive: true });
+		appendFileSync(path.join(AUDIT_DIRECTORY, fileName), `${entry}\n`, 'utf8');
+	} catch (error) {
+		console.error(`Failed to write audit event ${event}:`, error);
+	}
+}


### PR DESCRIPTION
Adds daily JSONL audit files for user-visible bot actions so we can measure which MessageContent-dependent features actually fire before migrating them to Discord AutoMod.

Events record feature names, outcomes, and relevant IDs. Message-reading triggers temporarily include the original message text for replacement analysis; save contents and non-triggering messages are excluded. Audit write failures are reported without interrupting the bot.