### PR TITLE
Stop storing raw message content

### DIFF
--- a/src/bot.ts
+++ b/src/bot.ts
@@ -307,7 +307,6 @@ export class Bot {
 				audit('auto_response.red_names', {
 					channelId: message.channel.id,
 					guildId: message.guildId,
-					temporaryMessageContent: message.content,
 					userId: message.author.id,
 				});
 				await message.reply({
@@ -321,7 +320,6 @@ export class Bot {
 				audit('auto_response.mr_mime', {
 					channelId: message.channel.id,
 					guildId: message.guildId,
-					temporaryMessageContent: message.content,
 					userId: message.author.id,
 				});
 				await message.reply({
@@ -336,7 +334,6 @@ export class Bot {
 				audit('auto_response.codes', {
 					channelId: message.channel.id,
 					guildId: message.guildId,
-					temporaryMessageContent: message.content,
 					userId: message.author.id,
 				});
 				await message.reply({

--- a/src/services/automod.ts
+++ b/src/services/automod.ts
@@ -114,10 +114,8 @@ export class ModerationService {
 			action: 'ban',
 			channelId: message.channel.id,
 			guildId: message.guildId,
-			temporaryMessageContent: message.content,
 			userId: message.author.id,
 		});
-		console.log(message.content);
 		await message.delete().catch(handleDiscordError);
 		message.member
 			?.ban({
@@ -145,7 +143,6 @@ export class ModerationService {
 			action: 'delete_and_warn',
 			channelId: message.channel.id,
 			guildId: message.guildId,
-			temporaryMessageContent: message.content,
 			userId: message.author.id,
 		});
 		await message.delete().catch(handleDiscordError);
@@ -173,7 +170,6 @@ export class ModerationService {
 				action: 'ban',
 				channelId: message.channel.id,
 				guildId: message.guildId,
-				temporaryMessageContent: message.content,
 				userId: message.author.id,
 			});
 			await message.delete().catch(handleDiscordError);
@@ -233,7 +229,6 @@ export class ModerationService {
 			channelId: message.channel.id,
 			guildId: message.guildId,
 			messageCount: 6,
-			temporaryMessageContent: message.content,
 			userId: message.author.id,
 			windowMs: 8_000,
 		});
@@ -295,7 +290,6 @@ export class ModerationService {
 			action: 'ban',
 			channelIds: keys,
 			guildId: message.guildId,
-			temporaryMessageContent: message.content,
 			userId: message.author.id,
 			windowMs: 10_000,
 		});

--- a/src/services/channelMod.ts
+++ b/src/services/channelMod.ts
@@ -49,7 +49,6 @@ export class ChannelModService {
 				action: 'delete',
 				channelId: message.channel.id,
 				guildId: message.guildId,
-				temporaryMessageContent: message.content,
 				userId: message.author.id,
 			});
 		}
@@ -68,7 +67,6 @@ export class ChannelModService {
 		audit('channel.bug_report_rejected', {
 			channelId: message.channel.id,
 			guildId: message.guildId,
-			temporaryMessageContent: message.content,
 			userId: message.author.id,
 		});
 
@@ -108,7 +106,6 @@ export class ChannelModService {
 		audit('channel.mobile_bug_report_rejected', {
 			channelId: message.channel.id,
 			guildId: message.guildId,
-			temporaryMessageContent: message.content,
 			userId: message.author.id,
 		});
 
@@ -144,7 +141,6 @@ export class ChannelModService {
 			audit('channel.idea_accepted', {
 				channelId: message.channel.id,
 				guildId: message.guildId,
-				temporaryMessageContent: message.content,
 				userId: message.author.id,
 			});
 			return;
@@ -156,7 +152,6 @@ export class ChannelModService {
 		audit('channel.idea_rejected', {
 			channelId: message.channel.id,
 			guildId: message.guildId,
-			temporaryMessageContent: message.content,
 			userId: message.author.id,
 		});
 

--- a/src/services/saves.ts
+++ b/src/services/saves.ts
@@ -92,7 +92,7 @@ export class SaveService {
 			return;
 		}
 
-		log(message.content);
+		log('received unsupported DM');
 	}
 
 	/**
@@ -124,18 +124,14 @@ export class SaveService {
 			return;
 		}
 
-		await this.checkSave(save, data, message);
+		await this.checkSave(save, message);
 	}
 
 	/**
 	 * Validates a decoded save against existing saves to detect cheating or
 	 * duplicate submissions, then either assigns a role or bans the user.
 	 */
-	private async checkSave(
-		save: string[],
-		data: string,
-		message: Message,
-	): Promise<void> {
+	private async checkSave(save: string[], message: Message): Promise<void> {
 		log('checking save');
 
 		const depth = save[1] ?? '0';
@@ -177,7 +173,6 @@ export class SaveService {
 				depth,
 				timeplayed: Math.round(timeplayed),
 				gameUID,
-				save: data,
 			});
 			await this._roleService.setRole(Number(depth), message);
 		} else if (!store.bannedFromRoles.includes(message.author.id)) {
@@ -194,7 +189,6 @@ export class SaveService {
 				timeplayed: Math.round(timeplayed),
 				gameUID,
 				userBanned,
-				save: data,
 			});
 		}
 	}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -5,7 +5,6 @@ export interface SaveEntry {
 	depth: string;
 	timeplayed: number;
 	gameUID: string;
-	save: string;
 }
 
 export interface BannedSaveEntry {
@@ -14,7 +13,6 @@ export interface BannedSaveEntry {
 	timeplayed: number;
 	gameUID: string;
 	userBanned: boolean;
-	save: string;
 }
 
 export interface DataStore {

--- a/src/utils/audit.ts
+++ b/src/utils/audit.ts
@@ -14,7 +14,7 @@ const AUDIT_DIRECTORY = path.join(process.cwd(), 'logs');
  * Appends one structured event to the daily audit file.
  *
  * @param event - Stable event name used for counting and filtering.
- * @param context - Relevant IDs, outcomes, and temporary content when provided.
+ * @param context - Relevant IDs and outcome metadata.
  */
 export function audit(event: string, context: AuditContext = {}): void {
 	try {


### PR DESCRIPTION
Stops writing raw Discord message text to audit and process logs, and stops including submitted save contents in new save records. The bot still retains the IDs and validation metadata used for moderation, duplicate detection, and role assignment.